### PR TITLE
Specify file encoding for species data

### DIFF
--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -174,7 +174,8 @@ fetch_bbs_data <- function(quiet = FALSE)
                                      "character",
                                      "character"),
                       header = F,
-                      widths = c(6,-1,5,-1,50,-1,50,-1,50,-1,50,-1,50,-1,50,-1,50)); if (!isTRUE(quiet)){pb$tick()}
+                      widths = c(6,-1,5,-1,50,-1,50,-1,50,-1,50,-1,50,-1,50,-1,50),
+                      fileEncoding = "iso-8859-1"); if (!isTRUE(quiet)){pb$tick()}
   unlink(temp); if (!isTRUE(quiet)){pb$tick()}
 
   species <- species[,-c(4,5)]


### PR DESCRIPTION
This avoids an invalid multibyte string error when reading the species data. Would solve #81.