### PR TITLE
Fix issue with inconsistent column names

### DIFF
--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -224,6 +224,12 @@ get_counts <- function(level, quiet) {
     tick(pb, quiet)
   }
 
+  # The "StateNum" column is inconsistently named - fix it to be consistent
+  bird <- lapply(bird, function(x){
+    names(x) <- ifelse(names(x) == "statenum", "StateNum", names(x))
+    x
+  })
+
   bird <- do.call(rbind, bird)
 
   # column case conventions differ for state vs. stop level data, so we set:


### PR DESCRIPTION

## Description

This PR ensures that columns in the bird count data have consistent case for the state number column. The 2018 BBS data introduced inconsistency, using "StateNum" in all cases but one, where "statenum" is used. This makes it impossible to `rbind` all of the count data together in the `get_counts` function. 

## Related Issue

#130

## Example

To test this, try:

```r
library(bbsBayes)
fetch_bbs_data(level = 'stop')
```

## Best Practices

This should not require any additional documentation or examples, as the syntax/usage is identical.