### PR TITLE
corrected the definition of fixedyear for the slope model

### DIFF
--- a/R/prepare-jags-data.R
+++ b/R/prepare-jags-data.R
@@ -33,7 +33,7 @@
 #'   \item{year}{Vector of years for each count}
 #'   \item{firstyr}{Vector of indicator variables as to whether an observer was a first year}
 #'   \item{nobservers}{Total number of observers}
-#'   \item{fixedyear}{Median of all years, included only with slope model}
+#'   \item{fixedyear}{Median of all years (ymin:ymax), included only with slope model}
 #'   \item{nknots}{Number of knots to use for smooting functions, included only with GAM}
 #'   \item{X.basis}{Basis function for n smoothing functions, included only with GAM}
 #'
@@ -376,7 +376,7 @@ prepare_jags_data <- function(strat_data = NULL,
     if (tolower(model) == "slope")
     {
       to_return <- c(to_return,
-                     list(fixedyear = stats::median(unique(birds$Year))))
+                     list(fixedyear = stats::median(unique(spsp_f$year))))
     }
 
     if (tolower(model) %in% c("gam", "gamye"))


### PR DESCRIPTION


## Description
I changed two lines of code in the prepare_jags_data function. The definition and description of the fixedyear object. After these changes, it will be scaled properly to center the year variables, which range from ymin:ymax (usually 1:53).

## Related Issue
NA

## Example
For a common analysis of the entire dataset, fixedyear will now equal 27, instead of 1992.

## Best Practices

