### PR TITLE
I've modified the stratify function to optionally lump some of the unidentified and split/lumped species (e.g., NOFL)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@ CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 ISSUES_TEMPLATE.md
 PULL_REQUEST_TEMPLATE.md
+generate-map-abundance.R
+

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ jags_mod_full_gam.RData
 temp.geofacet.pdf
 *output/
 *.EX.R
-
+R/*abundance.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,9 +28,9 @@ NeedsCompilation: no
 Description: The North American Breeding Bird Survey (BBS) is a long-running
   program that seeks to monitor the status and trends of the breeding birds in
   North America. Since its start in 1966, the BBS has accumulated over 50 years 
-  of data for over 300 species of North American Birds. Given the temporal and 
+  of data for over 500 species of North American Birds. Given the temporal and 
   spatial structure of the data, hierarchical Bayesian models are used to assess 
-  the status and trends of these 300+ species of birds. 'bbsBayes' allows you to perform 
+  the status and trends of these 500+ species of birds. 'bbsBayes' allows you to perform 
   hierarchical Bayesian analysis of BBS data. You can run a full
   model analysis for one or more species that you choose, or you can take
   more control and specify how the data should be stratified, prepared

--- a/R/stratify.R
+++ b/R/stratify.R
@@ -12,10 +12,13 @@
 #' @param bbs_data Raw BBS data saved as a list of 3 data frames.
 #'   Not necessary if you have already run \code{fetch_bbs_data}
 #' @param lump_species_forms Logical, default is TRUE, indicating that for
-#'   species with multiple forms, the "unidentified" form represents
-#'   the sum of observations for all forms. The underlying BBS database also
-#'   includes separate data for each form, and an unidentified category for
-#'   observations that were not specific to a particular form
+#'   species with multiple forms, the "unidentified" form is replaced by
+#'   the sum of observations for all forms (including the original unidentified obs).
+#'   The underlying BBS database includes separate data for each form,
+#'   and these separate forms are retained with their original names.
+#'   The original unidentified category for observations that were not specific to
+#'   a particular form are replaced by the combined observations. If the user
+#'   wishes to keep the unidentified form separate, this can be set to FALSE
 #' @param stratify_by Deprecated in favour of 'by'
 #'
 #' @return Large list (3 elements) consisting of:

--- a/R/stratify.R
+++ b/R/stratify.R
@@ -11,6 +11,11 @@
 #' @param quiet Should progress bars be suppressed?
 #' @param bbs_data Raw BBS data saved as a list of 3 data frames.
 #'   Not necessary if you have already run \code{fetch_bbs_data}
+#' @param lump_species_forms Logical, default is TRUE, indicating that for
+#'   species with multiple forms, the "unidentified" form represents
+#'   the sum of observations for all forms. The underlying BBS database also
+#'   includes separate data for each form, and an unidentified category for
+#'   observations that were not specific to a particular form
 #' @param stratify_by Deprecated in favour of 'by'
 #'
 #' @return Large list (3 elements) consisting of:
@@ -53,6 +58,7 @@
 stratify <- function(by = NULL,
                      sample_data = FALSE,
                      bbs_data = NULL,
+                     lump_species_forms = TRUE,
                      quiet = FALSE,
                      stratify_by = NULL)
 {
@@ -96,8 +102,49 @@ stratify <- function(by = NULL,
     load(file = paste0(bbs_dir$data(), "/bbs_raw_data.RData"))
   }
   if (!isTRUE(quiet)){pb$tick()}
+  species <- bbs_data$species
 
-  bird <- bbs_data$bird; if (!isTRUE(quiet)){pb$tick()}
+  bird <- bbs_data$bird
+  if (lump_species_forms){
+    lump_sp <- utils::read.csv(system.file("species-lump-split", "lump.csv", package = "bbsBayes"),stringsAsFactors = FALSE)
+  for(lumpi in 1:nrow(lump_sp)){
+    aou1 <- lump_sp[lumpi,"aou_original"]
+    sp_en <- lump_sp[lumpi,"english_out"]
+    sp_fr <- lump_sp[lumpi,"french_out"]
+    wsp <- which(species$sp.bbs == aou1)
+    species[wsp,"english"] <- sp_en
+    species[wsp,"french"] <- sp_fr
+
+    # replace original unidentified data with combined data from all forms
+    nadd <- lump_sp[lumpi,"n_add"]
+    aoulump <- lump_sp[lumpi,paste0("aou",1:nadd)]
+    tmp1 <- bird[which(bird$AOU %in% aou1),]
+    tmp2 <- bird[which(bird$AOU %in% aoulump),]
+    if(nrow(tmp1) > 0){
+      rem1 <- which(bird$AOU %in% aou1)
+    #bird <- bird[-which(bird$AOU %in% aou1),]
+    tmp <- rbind(tmp1,tmp2)
+    }else{
+      tmp <- tmp2
+    }
+    if(nrow(tmp) > 0){
+     tmp$AOU <- aou1
+    # bird <- rbind(bird,tmp)
+    }
+    if(lumpi == 1){
+      tmp_add <- tmp
+      rem <- rem1
+    }else{
+      tmp_add <- rbind(tmp_add,tmp)
+      rem <- c(rem,rem1)
+    }
+  }
+    bird <- bird[-rem,]
+    bird <- rbind(bird,tmp_add)
+
+  }
+
+  if (!isTRUE(quiet)){pb$tick()}
   route <- bbs_data$route; if (!isTRUE(quiet)){pb$tick()}
 
   if (by == "bbs_usgs")
@@ -153,6 +200,6 @@ stratify <- function(by = NULL,
 
   return(list(bird_strat = bird,
               route_strat = route,
-              species_strat = bbs_data$species,
+              species_strat = species,
               stratify_by = by))
 }

--- a/R/stratify.R
+++ b/R/stratify.R
@@ -105,7 +105,13 @@ stratify <- function(by = NULL,
   species <- bbs_data$species
 
   bird <- bbs_data$bird
-  if (lump_species_forms){
+
+  if (isFALSE(sample_data) & isTRUE(lump_species_forms)){
+    rem1 <- NULL
+    rem <- NULL
+    tmp1 <- NULL
+    tmp2 <- NULL
+    tmp <- NULL
     lump_sp <- utils::read.csv(system.file("species-lump-split", "lump.csv", package = "bbsBayes"),stringsAsFactors = FALSE)
   for(lumpi in 1:nrow(lump_sp)){
     aou1 <- lump_sp[lumpi,"aou_original"]

--- a/inst/species-lump-split/lump.csv
+++ b/inst/species-lump-split/lump.csv
@@ -1,0 +1,14 @@
+aou_original,english_original,english_out,french_out,n_add,aou1,aou2,aou3,aou4,aou5
+2973,unid. Dusky Grouse / Sooty Grouse,Blue Grouse (Dusky/Sooty),Tétras sombre (sombre/fuligineux) ,2,2970,2971,,,
+5677,(unid. race) Dark-eyed Junco ,Dark-eyed Junco (all forms),Junco ardoisé (toutes les formes),5,5671,5670,5680,5660,5690
+4123,(unid. Red/Yellow Shafted) Northern Flicker,Northern Flicker (all forms),Pic flamboyant (toutes les formes),3,4125,4120,4130,,
+5077,unid. Bullock's Oriole / Baltimore Oriole,Northern Oriole (Bullock's/Baltimore),Oriole du Nord (de Bullock/de Baltimore),2,5080,5070,5078,,
+3370,Red-tailed Hawk,Red-tailed Hawk (all forms),Buse à queue rousse (toutes les formes),1,3380,,,,
+4022,unid. sapsucker,Sapsuckers (Yellow-bellied/Red-naped/Red-breasted/Williamson's),Pics buveur de sève (maculé/à nuque rouge/à poitrine rouge),4,4020,4021,4031,4032,
+1690,Snow Goose,Snow Goose (all forms),Oie des neiges (toutes les formes),1,1691,,,,
+6295,unid. Cassin's Vireo / Blue-headed Vireo,Solitary Vireo (Blue-headed/Cassin's),Viréo à tête bleue (à tête bleue/de Cassin),3,6292,6291,6290,,
+4665,unid. Alder Flycatcher / Willow Flycatcher,Traill's Flycatcher (Alder/Willow),Moucherolle de Traill (des aulnes/ des saules),2,4661,4660,,,
+4642,unid. Cordilleran / Pacific-slope Flycatcher,Western Flycatcher (Cordilleran/Pacific-slope),Moucherolle côtier (des ravins/ côtier),2,4641,4640,,,
+12,unid. Western Grebe / Clark's Grebe,Western Grebe (Clark's/Western),Grèbe élégant (à face blanche/élégant),2,10,11,,,
+6556,(unid. Myrtle/Audubon's) Yellow-rumped Warbler,Yellow-rumped Warbler (all forms),Paruline à croupion jaune (toutes les formes),2,6550,6560,,,
+5275,unid. Common Redpoll / Hoary Redpoll,Redpoll (Common/Hoary),Sizerin (Flammé/Blanchâtre),2,5270,5280,,,

--- a/man/stratify.Rd
+++ b/man/stratify.Rd
@@ -5,7 +5,7 @@
 \title{Stratify raw Breeding Bird Survey data}
 \usage{
 stratify(by = NULL, sample_data = FALSE, bbs_data = NULL,
-  quiet = FALSE, stratify_by = NULL)
+  lump_species_forms = TRUE, quiet = FALSE, stratify_by = NULL)
 }
 \arguments{
 \item{by}{String argument of stratification type.
@@ -16,6 +16,12 @@ Defaults to FALSE.}
 
 \item{bbs_data}{Raw BBS data saved as a list of 3 data frames.
 Not necessary if you have already run \code{fetch_bbs_data}}
+
+\item{lump_species_forms}{Logical, default is TRUE, indicating that for
+species with multiple forms, the "unidentified" form represents
+the sum of observations for all forms. The underlying BBS database also
+includes separate data for each form, and an unidentified category for
+observations that were not specific to a particular form}
 
 \item{quiet}{Should progress bars be suppressed?}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The stratify function now includes an option to lump (default) or split (optional) species forms for 13 species/groups that have been lumped or split since the beginning of the BBS (Northern Flicker, Yellow-rumped Warbler). 

## Related Issue
at least a partial fix to #63 

## Example
This new lumping approach is the default in stratify, because the split forms are meaningless for conservation, and in many situations introduce weird temporal biases. 
Also, the default doesn't remove any of the individual or split "species". For example, the all races of Dark-eyed Junco are combined by default into a new "Dark-eyed Junco" species, but each individual race is retained. Similarly, although the split species group Blue Grouse was split into Dusky and Sooty grouse, the default is to combine the dusky and sooty with the unidentified dusky/sooty into the new species "Blue Grouse", the two original forms are also retained, but the "unidentified" species is replaced iwth the combined.

## Best Practices
This change introduces some problems with the status bar. It currently hangs at 12% for a long time. Sorry....
There is some documentation added, but no examples (not sure an example is relevant)
