### PR TITLE
fetch_bbs_data stop level counts issue

### DIFF
--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -310,10 +310,10 @@ get_counts <- function(level, quiet, sb_conn) {
   #    in the 10th data frame of bird, so get rid of countrynum.
   #    Only relevant for level = "stop", this will probably be taken out
   #    next year lol
-  if (level == "stop")
-  {
-    bird[[10]] <- bird[[10]][-c(2)]
-  }
+  #if (level == "stop") # issue appears to be fixed; throws an error with do.call(rbind) below.
+  #{
+  #  bird[[10]] <- bird[[10]][-c(2)]
+  #}
 
 
   # The "StateNum" column is inconsistently named - fix it to be consistent


### PR DESCRIPTION
fetch_bbs_data() was throwing an error in rbind() call for the 10th data frame -- dimensions not the same. Commented out the workaround for stop-level counts in source code to get working again. 

