### PR TITLE
correction to the likelihood statement in the slope models (missing i…

### DIFF
--- a/inst/models/slope.jags
+++ b/inst/models/slope.jags
@@ -6,7 +6,7 @@ model
 
 	for( k in 1 : ncounts )
 	{
-		Eloglambda[k] <- beta[strat[k]] * (year[k] - fixedyear) + obs[strat[k],obser[k]] + eta*firstyr[k] + yeareffect[strat[k],year[k]]
+		Eloglambda[k] <- strata[strat[k]] + beta[strat[k]] * (year[k] - fixedyear) + obs[strat[k],obser[k]] + eta*firstyr[k] + yeareffect[strat[k],year[k]]
 	 	loglambda[k] ~ dnorm(Eloglambda[k], taunoise)
 	 	log(lambda[k]) <- loglambda[k]
 		count[k] ~ dpois(lambda[k])

--- a/inst/models/slope.t.jags
+++ b/inst/models/slope.t.jags
@@ -6,7 +6,7 @@ model
 
 	for( k in 1 : ncounts )
 	{
-		Eloglambda[k] <- beta[strat[k]] * (year[k] - fixedyear) + obs[strat[k],obser[k]] + eta*firstyr[k] + yeareffect[strat[k],year[k]]
+		Eloglambda[k] <- strata[strat[k]] + beta[strat[k]] * (year[k] - fixedyear) + obs[strat[k],obser[k]] + eta*firstyr[k] + yeareffect[strat[k],year[k]]
 	 	loglambda[k] ~ dt(Eloglambda[k], taunoise, nu)
 	 	log(lambda[k]) <- loglambda[k]
 		count[k] ~ dpois(lambda[k])


### PR DESCRIPTION
When we adjusted the names in the models, I introduced an error. I accidentally removed the stratum level intercepts from the likelihood statements in the two slope models.

This is a simple pull request to put them back in.

Sorry about that.

only change is to add "strata[strat[k]] + " to the first line of the two slope models.