### PR TITLE
alternative fix for fetch_bbs_data - maybe fixes #192

### DIFF
--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -213,7 +213,8 @@ fetch_bbs_data <- function(level = "state",
                                             "character",
                                             "character"),
                              widths = c(6, -1, 5, -1, 50, -1, 50, -1, 50, -1,
-                                        50, -1, 50, -1, 50, -1, 50))
+                                        50, -1, 50, -1, 50, -1, 50),
+                             fileEncoding = "latin1")
   unlink(temp)
   tick(pb, quiet)
 


### PR DESCRIPTION
With the recent fix to `fetch_bbs_data()`, #191 , I get the error described in #192 . 
There seems to be something, perhaps system-dependent, that doesn't like the encoding of the speciesList.txt file.

For my system (same one listed in #192) putting the `fileEncoding` argument back into the `read.fwf()` function fixes this error, but only if the argument is `fileEncoding = "latin1"`. 

I don't know if this will then cause similar failures on other systems in the way that the earlier encoding argument cased #191.

Oh, and I should add this works on my system for both 2020 and 2022 releases.