### PR TITLE
Fix encoding for `fetch_bbs_data()` and `stratify()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bbsBayes
 Type: Package
 Title: Hierarchical Bayesian Analysis of North American BBS Data
-Version: 2.5.1
+Version: 2.5.1.9000
 Date: 2022-07-18
 Authors@R: c(person("Brandon P.M.", "Edwards", role = c("aut", "cre"),
                      email = "brandonedwards3@cmail.carleton.ca"),

--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -129,7 +129,7 @@ fetch_bbs_data <- function(level = "state",
   routes <- utils::read.csv(utils::unzip(zipfile = full_path,
                                          exdir = temp),
                             stringsAsFactors = FALSE,
-                            fileEncoding = "latin1")
+                            fileEncoding = get_encoding())
   unlink(temp)
   tick(pb, quiet)
 
@@ -215,7 +215,7 @@ fetch_bbs_data <- function(level = "state",
                                             "character"),
                              widths = c(6, -1, 5, -1, 50, -1, 50, -1, 50, -1,
                                         50, -1, 50, -1, 50, -1, 50),
-                             fileEncoding = "latin1")
+                             fileEncoding = get_encoding())
   unlink(temp)
   tick(pb, quiet)
 
@@ -364,3 +364,9 @@ tick <- function(pb, quiet) {
     pb$tick()
   }
 }
+
+get_encoding <- function() {
+  if(l10n_info()[["UTF-8"]]) e <- "latin1" else e <- ""
+  e
+}
+

--- a/R/fetch-bbs-data.R
+++ b/R/fetch-bbs-data.R
@@ -128,7 +128,8 @@ fetch_bbs_data <- function(level = "state",
 
   routes <- utils::read.csv(utils::unzip(zipfile = full_path,
                                          exdir = temp),
-                            stringsAsFactors = FALSE)
+                            stringsAsFactors = FALSE,
+                            fileEncoding = "latin1")
   unlink(temp)
   tick(pb, quiet)
 
@@ -213,7 +214,8 @@ fetch_bbs_data <- function(level = "state",
                                             "character",
                                             "character"),
                              widths = c(6, -1, 5, -1, 50, -1, 50, -1, 50, -1,
-                                        50, -1, 50, -1, 50, -1, 50))
+                                        50, -1, 50, -1, 50, -1, 50),
+                             fileEncoding = "latin1")
   unlink(temp)
   tick(pb, quiet)
 

--- a/R/stratify.R
+++ b/R/stratify.R
@@ -93,7 +93,7 @@ stratify <- function(by = NULL,
                                          "lump.csv",
                                          package = "bbsBayes"),
                              stringsAsFactors = FALSE,
-                             fileEncoding = "latin1")
+                             fileEncoding = get_encoding())
   pb_len <- 8
   if (isTRUE(lump_species_forms))
   {

--- a/R/stratify.R
+++ b/R/stratify.R
@@ -92,7 +92,8 @@ stratify <- function(by = NULL,
   lump_sp <- utils::read.csv(system.file("species-lump-split",
                                          "lump.csv",
                                          package = "bbsBayes"),
-                             stringsAsFactors = FALSE)
+                             stringsAsFactors = FALSE,
+                             fileEncoding = "latin1")
   pb_len <- 8
   if (isTRUE(lump_species_forms))
   {


### PR DESCRIPTION
This should fix #192 by providing explicit file encodings of latin1. 

1. Install this PR by going into your `bbsBayes` project and fetching this PR
```
usethis::pr_fetch(197)
```

2. Use `devtools::load_all(".")` to load the current version of the package (also Ctrl-Shift-L)

3. To test, try the following
```
fetch_bbs_data("state", force = TRUE)  # Should have no errors

b <- load_bbs_data()
head(b$species)     # Should have proper accents in French names

s <- stratify(by = "bbs_usgs")
s$species_strat[634:638,]  # Should have proper accents, including in 'lumped' species
```

4. Once you're done, get rid of the PR with
```
usethis::pr_finish()
```

Let me know how it goes!